### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Attentively/BAO/Attentively.php
+++ b/CRM/Attentively/BAO/Attentively.php
@@ -46,7 +46,7 @@ class CRM_Attentively_BAO_Attentively {
   }
   
   static public function updateAttentivelyAuth($params) {
-    $accessToken = CRM_Utils_Array::value('access_token', $params);
+    $accessToken = $params['access_token'] ?? NULL;
     if ($accessToken) {
       CRM_Core_DAO::singleValueQuery("UPDATE civicrm_option_value SET value = '{$accessToken}' WHERE name = 'access_token'");
     }

--- a/CRM/Attentively/BAO/Query.php
+++ b/CRM/Attentively/BAO/Query.php
@@ -213,7 +213,6 @@ class CRM_Attentively_BAO_Query extends CRM_Contact_BAO_Query_Interface {
     $networks = CRM_Attentively_BAO_Attentively::getNetworkList();
     foreach ($value as $dontCare => $pOption) {
       $clauses[] = " ( civicrm_attentively_member_network.name $compareOP '{$pOption}' ) ";
-      $field = CRM_Utils_Array::value($pOption, $this->getFields());
       $title = CRM_Utils_Array::value($pOption, $networks, $pOption);
       $qill[] = " Social Media $compareOP $title ";
     }


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.