### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/Attentively/Pullmembers.php
+++ b/api/v3/Attentively/Pullmembers.php
@@ -6,7 +6,7 @@
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_attentively_pullmembers() {
   $result = CRM_Attentively_BAO_Attentively::pullMembers();

--- a/api/v3/Attentively/Pullposts.php
+++ b/api/v3/Attentively/Pullposts.php
@@ -7,7 +7,7 @@
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_attentively_pullposts() {
   $result = CRM_Attentively_BAO_Attentively::pullPosts();

--- a/api/v3/Attentively/Pullwatchedterms.php
+++ b/api/v3/Attentively/Pullwatchedterms.php
@@ -7,7 +7,7 @@
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_attentively_pullwatchedterms() {
   $result = CRM_Attentively_BAO_Attentively::pullWatchedTerms();

--- a/api/v3/Attentively/Pushmembers.php
+++ b/api/v3/Attentively/Pushmembers.php
@@ -7,7 +7,7 @@
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_attentively_pushmembers() {
   $result = CRM_Attentively_BAO_Attentively::pushMembers();

--- a/api/v3/Attentively/Pushwatchedterms.php
+++ b/api/v3/Attentively/Pushwatchedterms.php
@@ -7,7 +7,7 @@
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_attentively_pushwatchedterms() {
   $result = CRM_Attentively_BAO_Attentively::pushWatchedTerms();


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.